### PR TITLE
Remove shutdown command, replace call to it with exitControl

### DIFF
--- a/ApplicationControlWidget.py
+++ b/ApplicationControlWidget.py
@@ -65,8 +65,8 @@ class ApplicationControlWidget(QWidget):
     def issueCommandStandby(self):
         self.MTM1M3.issueCommandThenWait_standby(False)
 
-    def issueCommandShutdown(self):
-        self.MTM1M3.issueCommandThenWait_shutdown(False)
+    def issueCommandExitControl(self):
+        self.MTM1M3.issueCommandThenWait_exitControl(False)
 
     def processEventDetailedState(self, data):
         state = data[len(data) - 1].detailedState
@@ -74,7 +74,7 @@ class ApplicationControlWidget(QWidget):
             QTHelpers.updateButton(self.button1, "Start", self.issueCommandStart)
             QTHelpers.hideButton(self.button2)
             QTHelpers.hideButton(self.button3)
-            QTHelpers.updateButton(self.button4, "Shutdown", self.issueCommandShutdown)
+            QTHelpers.updateButton(self.button4, "Exit Control", self.issueCommandExitControl)
         elif state == DetailedStates.DisabledState:
             QTHelpers.updateButton(self.button1, "Enable", self.issueCommandEnable)
             QTHelpers.hideButton(self.button2)

--- a/MTM1M3Controller.py
+++ b/MTM1M3Controller.py
@@ -36,7 +36,7 @@ class MTM1M3Controller:
         self.sal.salProcessor("MTM1M3_command_programILC")
         self.sal.salProcessor("MTM1M3_command_raiseM1M3")
         self.sal.salProcessor("MTM1M3_command_resetPID")
-        self.sal.salProcessor("MTM1M3_command_shutdown")
+        self.sal.salProcessor("MTM1M3_command_exitControl")
         self.sal.salProcessor("MTM1M3_command_stopHardpointMotion")
         self.sal.salProcessor("MTM1M3_command_testAir")
         self.sal.salProcessor("MTM1M3_command_testForceActuator")
@@ -148,7 +148,7 @@ class MTM1M3Controller:
         self.commandSubscribers_programILC = []
         self.commandSubscribers_raiseM1M3 = []
         self.commandSubscribers_resetPID = []
-        self.commandSubscribers_shutdown = []
+        self.commandSubscribers_exitControl = []
         self.commandSubscribers_stopHardpointMotion = []
         self.commandSubscribers_testAir = []
         self.commandSubscribers_testForceActuator = []
@@ -589,18 +589,18 @@ class MTM1M3Controller:
         if "command_resetPID" not in self.topicsSubscribedToo:
             self.topicsSubscribedToo["command_resetPID"] = [self.acceptCommand_resetPID, self.commandSubscribers_resetPID]
 
-    def acceptCommand_shutdown(self):
-        data = MTM1M3_command_shutdownC()
-        result = self.sal.acceptCommand_shutdown(data)
+    def acceptCommand_exitControl(self):
+        data = MTM1M3_command_exitControlC()
+        result = self.sal.acceptCommand_exitControl(data)
         return result, data
 
-    def ackCommand_shutdown(self, cmdId, ackCode, errorCode, description):
-        return self.sal.ackCommand_shutdown(cmdId, ackCode, errorCode, description)
+    def ackCommand_exitControl(self, cmdId, ackCode, errorCode, description):
+        return self.sal.ackCommand_exitControl(cmdId, ackCode, errorCode, description)
 
-    def subscribeCommand_shutdown(self, action):
-        self.commandSubscribers_shutdown.append(action)
-        if "command_shutdown" not in self.topicsSubscribedToo:
-            self.topicsSubscribedToo["command_shutdown"] = [self.acceptCommand_shutdown, self.commandSubscribers_shutdown]
+    def subscribeCommand_exitControl(self, action):
+        self.commandSubscribers_exitControl.append(action)
+        if "command_exitControl" not in self.topicsSubscribedToo:
+            self.topicsSubscribedToo["command_exitControl"] = [self.acceptCommand_exitControl, self.commandSubscribers_exitControl]
 
     def acceptCommand_stopHardpointMotion(self):
         data = MTM1M3_command_stopHardpointMotionC()

--- a/MTM1M3Remote.py
+++ b/MTM1M3Remote.py
@@ -36,7 +36,6 @@ class MTM1M3Remote:
         self.sal.salCommand("MTM1M3_command_programILC")
         self.sal.salCommand("MTM1M3_command_raiseM1M3")
         self.sal.salCommand("MTM1M3_command_resetPID")
-        self.sal.salCommand("MTM1M3_command_shutdown")
         self.sal.salCommand("MTM1M3_command_stopHardpointMotion")
         self.sal.salCommand("MTM1M3_command_testAir")
         self.sal.salCommand("MTM1M3_command_testForceActuator")
@@ -896,27 +895,6 @@ class MTM1M3Remote:
     def issueCommandThenWait_resetPID(self, pid, timeoutInSeconds = 10):
         cmdId = self.issueCommand_resetPID(pid)
         return self.waitForCompletion_resetPID(cmdId, timeoutInSeconds)
-
-    def issueCommand_shutdown(self, value):
-        data = MTM1M3_command_shutdownC()
-        data.value = value
-
-        return self.sal.issueCommand_shutdown(data)
-
-    def getResponse_shutdown(self):
-        data = MTM1M3_ackcmdC()
-        result = self.sal.getResponse_shutdown(data)
-        return result, data
-        
-    def waitForCompletion_shutdown(self, cmdId, timeoutInSeconds = 10):
-        waitResult = self.sal.waitForCompletion_shutdown(cmdId, timeoutInSeconds)
-        #ackResult, ack = self.getResponse_shutdown()
-        #return waitResult, ackResult, ack
-        return waitResult
-        
-    def issueCommandThenWait_shutdown(self, value, timeoutInSeconds = 10):
-        cmdId = self.issueCommand_shutdown(value)
-        return self.waitForCompletion_shutdown(cmdId, timeoutInSeconds)
 
     def issueCommand_stopHardpointMotion(self, value):
         data = MTM1M3_command_stopHardpointMotionC()


### PR DESCRIPTION
Shutdown command was introduced before standard exitControl command was
added to SALGenerics. This patch removes shutdown call and replace it
with exitControl.